### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/src/_data/drops.json
+++ b/src/_data/drops.json
@@ -3,7 +3,7 @@
         "material_id": "rotten_flesh",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/ac/Rotten_Flesh_JE3_BE2.png",
         "name": "rotten flesh",
-        "url": "https://minecraft.fandom.com/wiki/Rotten_Flesh",
+        "url": "https://minecraft.wiki/w/Rotten_Flesh",
         "price": "1",
         "stack": "64"
     },
@@ -11,7 +11,7 @@
         "material_id": "spider_eye",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1a/Spider_Eye_JE2_BE2.png",
         "name": "spider eye",
-        "url": "https://minecraft.fandom.com/wiki/Spider_Eye",
+        "url": "https://minecraft.wiki/w/Spider_Eye",
         "price": "5",
         "stack": "64"
     },
@@ -19,7 +19,7 @@
         "material_id": "string",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/13/String_JE2_BE2.png",
         "name": "string",
-        "url": "https://minecraft.fandom.com/wiki/String",
+        "url": "https://minecraft.wiki/w/String",
         "price": "2",
         "stack": "64"
     },
@@ -27,7 +27,7 @@
         "material_id": "gunpowder",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/40/Gunpowder_JE2_BE2.png",
         "name": "gunpowder",
-        "url": "https://minecraft.fandom.com/wiki/Gunpowder",
+        "url": "https://minecraft.wiki/w/Gunpowder",
         "price": "10",
         "stack": "64"
     },
@@ -35,7 +35,7 @@
         "material_id": "bone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/3a/Bone_JE3_BE2.png",
         "name": "bone",
-        "url": "https://minecraft.fandom.com/wiki/Bone",
+        "url": "https://minecraft.wiki/w/Bone",
         "price": "5",
         "stack": "64"
     },
@@ -43,7 +43,7 @@
         "material_id": "leather",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/6/6d/Leather_JE2_BE2.png",
         "name": "leather",
-        "url": "https://minecraft.fandom.com/wiki/Leather",
+        "url": "https://minecraft.wiki/w/Leather",
         "price": "10",
         "stack": "64"
     },
@@ -51,7 +51,7 @@
         "material_id": "rabbit_hide",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/3e/Rabbit_Hide_JE3_BE2.png",
         "name": "rabbit hide",
-        "url": "https://minecraft.fandom.com/wiki/Rabbit_Hide",
+        "url": "https://minecraft.wiki/w/Rabbit_Hide",
         "price": "2",
         "stack": "64"
     },
@@ -59,7 +59,7 @@
         "material_id": "feather",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/e2/Feather_JE3_BE2.png",
         "name": "feather",
-        "url": "https://minecraft.fandom.com/wiki/Feather",
+        "url": "https://minecraft.wiki/w/Feather",
         "price": "2",
         "stack": "64"
     },
@@ -67,7 +67,7 @@
         "material_id": "ink_sac",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c6/Ink_Sac_JE2_BE2.png",
         "name": "ink sac",
-        "url": "https://minecraft.fandom.com/wiki/Ink_Sac",
+        "url": "https://minecraft.wiki/w/Ink_Sac",
         "price": "5",
         "stack": "64"
     },
@@ -75,7 +75,7 @@
         "material_id": "phantom_membrane",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/5c/Phantom_Membrane_JE2_BE2.png",
         "name": "phantom membrane",
-        "url": "https://minecraft.fandom.com/wiki/Phantom_Membrane",
+        "url": "https://minecraft.wiki/w/Phantom_Membrane",
         "price": "5",
         "stack": "64"
     },
@@ -83,7 +83,7 @@
         "material_id": "slimeball",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d0/Slimeball_JE2_BE2.png",
         "name": "slimeball",
-        "url": "https://minecraft.fandom.com/wiki/Slimeball",
+        "url": "https://minecraft.wiki/w/Slimeball",
         "price": "10",
         "stack": "64"
     },
@@ -91,7 +91,7 @@
         "material_id": "slime_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/bb/Slime_Block_JE2_BE3.png",
         "name": "slime block",
-        "url": "https://minecraft.fandom.com/wiki/Slime_Block",
+        "url": "https://minecraft.wiki/w/Slime_Block",
         "price": "90",
         "stack": "64"
     },
@@ -99,7 +99,7 @@
         "material_id": "honey_bottle",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c2/Honey_Bottle_JE1_BE2.png",
         "name": "honey bottle",
-        "url": "https://minecraft.fandom.com/wiki/Honey_Bottle",
+        "url": "https://minecraft.wiki/w/Honey_Bottle",
         "price": "3",
         "stack": "64"
     },
@@ -107,7 +107,7 @@
         "material_id": "honey_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c4/Honey_Block_JE1_BE2.png",
         "name": "honey block",
-        "url": "https://minecraft.fandom.com/wiki/Honey_Block",
+        "url": "https://minecraft.wiki/w/Honey_Block",
         "price": "10",
         "stack": "64"
     },
@@ -115,7 +115,7 @@
         "material_id": "ender_pearl",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/f6/Ender_Pearl_JE3_BE2.png",
         "name": "ender pearl",
-        "url": "https://minecraft.fandom.com/wiki/Ender_Pearl",
+        "url": "https://minecraft.wiki/w/Ender_Pearl",
         "price": "16",
         "stack": "64"
     },
@@ -123,7 +123,7 @@
         "material_id": "ghast_tear",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c5/Ghast_Tear_JE2_BE2.png",
         "name": "ghast tear",
-        "url": "https://minecraft.fandom.com/wiki/Ghast_Tear",
+        "url": "https://minecraft.wiki/w/Ghast_Tear",
         "price": "80",
         "stack": "64"
     },
@@ -131,7 +131,7 @@
         "material_id": "blaze_rod",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/87/Blaze_Rod_JE1_BE1.png",
         "name": "blaze rod",
-        "url": "https://minecraft.fandom.com/wiki/Blaze_Rod",
+        "url": "https://minecraft.wiki/w/Blaze_Rod",
         "price": "50",
         "stack": "64"
     },
@@ -139,7 +139,7 @@
         "material_id": "magma_cream",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/08/Magma_Cream_JE3_BE2.png",
         "name": "magma cream",
-        "url": "https://minecraft.fandom.com/wiki/Magma_Cream",
+        "url": "https://minecraft.wiki/w/Magma_Cream",
         "price": "30",
         "stack": "64"
     },
@@ -147,7 +147,7 @@
         "material_id": "nautilus_shell",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1a/Nautilus_Shell_JE1_BE2.png",
         "name": "nautilus shell",
-        "url": "https://minecraft.fandom.com/wiki/Nautilus_Shell",
+        "url": "https://minecraft.wiki/w/Nautilus_Shell",
         "price": "50",
         "stack": "64"
     },
@@ -155,7 +155,7 @@
         "material_id": "wither_skeleton_skull",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/5d/Wither_Skeleton_Skull_%288%29.png",
         "name": "wither skeleton skull",
-        "url": "https://minecraft.fandom.com/wiki/Wither_Skeleton_Skull",
+        "url": "https://minecraft.wiki/w/Wither_Skeleton_Skull",
         "price": "?",
         "stack": "64"
     },
@@ -163,7 +163,7 @@
         "material_id": "nether_star",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d0/Nether_Star_JE3_BE2.png",
         "name": "nether star",
-        "url": "https://minecraft.fandom.com/wiki/Nether_Star",
+        "url": "https://minecraft.wiki/w/Nether_Star",
         "price": "250",
         "stack": "64"
     },
@@ -171,7 +171,7 @@
         "material_id": "wither_rose",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/fa/Wither_Rose_JE1_BE1.png",
         "name": "wither rose",
-        "url": "https://minecraft.fandom.com/wiki/Wither_Rose",
+        "url": "https://minecraft.wiki/w/Wither_Rose",
         "price": "?",
         "stack": "64"
     }

--- a/src/_data/earth.json
+++ b/src/_data/earth.json
@@ -3,7 +3,7 @@
         "material_id": "dirt",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/9b/Dirt_JE2_BE2.png",
         "name": "dirt",
-        "url": "https://minecraft.fandom.com/wiki/Dirt",
+        "url": "https://minecraft.wiki/w/Dirt",
         "price": "1",
         "stack": "64"
     },
@@ -11,7 +11,7 @@
         "material_id": "grass_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/93/Grass_Block_JE7_BE6.png",
         "name": "grass block",
-        "url": "https://minecraft.fandom.com/wiki/Grass_Block",
+        "url": "https://minecraft.wiki/w/Grass_Block",
         "price": "2",
         "stack": "64"
     },
@@ -19,7 +19,7 @@
         "material_id": "coarse_dirt",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d8/Coarse_Dirt_JE1_BE1.png",
         "name": "coarse dirt",
-        "url": "https://minecraft.fandom.com/wiki/Coarse_Dirt",
+        "url": "https://minecraft.wiki/w/Coarse_Dirt",
         "price": "2",
         "stack": "64"
     },
@@ -27,7 +27,7 @@
         "material_id": "gravel",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/9d/Gravel_JE5_BE4.png",
         "name": "gravel",
-        "url": "https://minecraft.fandom.com/wiki/Gravel",
+        "url": "https://minecraft.wiki/w/Gravel",
         "price": "2",
         "stack": "64"
     },
@@ -35,7 +35,7 @@
         "material_id": "podzol",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/94/Podzol_JE2_BE2.png",
         "name": "podzol",
-        "url": "https://minecraft.fandom.com/wiki/Podzol",
+        "url": "https://minecraft.wiki/w/Podzol",
         "price": "3",
         "stack": "64"
     },
@@ -43,7 +43,7 @@
         "material_id": "mycelium",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/86/Mycelium_JE2_BE2.png",
         "name": "mycelium",
-        "url": "https://minecraft.fandom.com/wiki/Mycelium",
+        "url": "https://minecraft.wiki/w/Mycelium",
         "price": "10",
         "stack": "64"
     }

--- a/src/_data/food.json
+++ b/src/_data/food.json
@@ -3,7 +3,7 @@
         "material_id": "bread",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/44/Bread_JE3_BE3.png",
         "name": "bread",
-        "url": "https://minecraft.fandom.com/wiki/Bread",
+        "url": "https://minecraft.wiki/w/Bread",
         "price": "6",
         "stack": "64"
     },
@@ -11,7 +11,7 @@
         "material_id": "beef",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/0f/Raw_Beef_JE4_BE3.png",
         "name": "raw beef",
-        "url": "https://minecraft.fandom.com/wiki/Raw_Beef",
+        "url": "https://minecraft.wiki/w/Raw_Beef",
         "price": "7",
         "stack": "64"
     },
@@ -19,7 +19,7 @@
         "material_id": "cooked_beef",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/04/Steak_JE4_BE3.png",
         "name": "steak",
-        "url": "https://minecraft.fandom.com/wiki/Steak",
+        "url": "https://minecraft.wiki/w/Steak",
         "price": "8",
         "stack": "64"
     },
@@ -27,7 +27,7 @@
         "material_id": "porkchop",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/e0/Raw_Porkchop_JE3_BE3.png",
         "name": "raw porkchop",
-        "url": "https://minecraft.fandom.com/wiki/Raw_Porkchop",
+        "url": "https://minecraft.wiki/w/Raw_Porkchop",
         "price": "7",
         "stack": "64"
     },
@@ -35,7 +35,7 @@
         "material_id": "cooked_porkchop",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/ee/Cooked_Porkchop_JE4_BE3.png",
         "name": "cooked porkchop",
-        "url": "https://minecraft.fandom.com/wiki/Cooked_Porkchop",
+        "url": "https://minecraft.wiki/w/Cooked_Porkchop",
         "price": "8",
         "stack": "64"
     },
@@ -43,7 +43,7 @@
         "material_id": "mutton",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/f3/Raw_Mutton_JE3_BE2.png",
         "name": "raw mutton",
-        "url": "https://minecraft.fandom.com/wiki/Raw_Mutton",
+        "url": "https://minecraft.wiki/w/Raw_Mutton",
         "price": "5",
         "stack": "64"
     },
@@ -51,7 +51,7 @@
         "material_id": "cooked_mutton",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7d/Cooked_Mutton_JE3_BE2.png",
         "name": "cooked mutton",
-        "url": "https://minecraft.fandom.com/wiki/Cooked_Mutton",
+        "url": "https://minecraft.wiki/w/Cooked_Mutton",
         "price": "6",
         "stack": "64"
     },
@@ -59,7 +59,7 @@
         "material_id": "chicken",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/51/Raw_Chicken_JE3_BE3.png",
         "name": "raw chicken",
-        "url": "https://minecraft.fandom.com/wiki/Raw_Chicken",
+        "url": "https://minecraft.wiki/w/Raw_Chicken",
         "price": "5",
         "stack": "64"
     },
@@ -67,7 +67,7 @@
         "material_id": "cooked_chicken",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/6/66/Cooked_Chicken_JE3_BE3.png",
         "name": "cooked chicken",
-        "url": "https://minecraft.fandom.com/wiki/Cooked_Chicken",
+        "url": "https://minecraft.wiki/w/Cooked_Chicken",
         "price": "6",
         "stack": "64"
     },
@@ -75,7 +75,7 @@
         "material_id": "rabbit",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/72/Raw_Rabbit_JE3_BE2.png",
         "name": "raw rabbit",
-        "url": "https://minecraft.fandom.com/wiki/Raw_Rabbit",
+        "url": "https://minecraft.wiki/w/Raw_Rabbit",
         "price": "3",
         "stack": "64"
     },
@@ -83,7 +83,7 @@
         "material_id": "cooked_rabbit",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1b/Cooked_Rabbit_JE3_BE2.png",
         "name": "cooked rabbit",
-        "url": "https://minecraft.fandom.com/wiki/Cooked_Rabbit",
+        "url": "https://minecraft.wiki/w/Cooked_Rabbit",
         "price": "4",
         "stack": "64"
     },
@@ -91,7 +91,7 @@
         "material_id": "cod",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/ef/Raw_Cod_JE4_BE2.png",
         "name": "raw cod",
-        "url": "https://minecraft.fandom.com/wiki/Raw_Cod",
+        "url": "https://minecraft.wiki/w/Raw_Cod",
         "price": "3",
         "stack": "64"
     },
@@ -99,7 +99,7 @@
         "material_id": "cooked_cod",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/53/Cooked_Cod_JE4_BE3.png",
         "name": "cooked cod",
-        "url": "https://minecraft.fandom.com/wiki/Cooked_Cod",
+        "url": "https://minecraft.wiki/w/Cooked_Cod",
         "price": "4",
         "stack": "64"
     },
@@ -107,7 +107,7 @@
         "material_id": "salmon",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/75/Raw_Salmon_JE2_BE2.png",
         "name": "raw salmon",
-        "url": "https://minecraft.fandom.com/wiki/Raw_Salmon",
+        "url": "https://minecraft.wiki/w/Raw_Salmon",
         "price": "4",
         "stack": "64"
     },
@@ -115,7 +115,7 @@
         "material_id": "cooked_salmon",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/2b/Cooked_Salmon_JE2_BE2.png",
         "name": "cooked salmon",
-        "url": "https://minecraft.fandom.com/wiki/Cooked_Salmon",
+        "url": "https://minecraft.wiki/w/Cooked_Salmon",
         "price": "5",
         "stack": "64"
     },
@@ -123,7 +123,7 @@
         "material_id": "pufferfish",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/02/Pufferfish_%28item%29_JE5_BE2.png",
         "name": "pufferfish",
-        "url": "https://minecraft.fandom.com/wiki/Pufferfish_(item)",
+        "url": "https://minecraft.wiki/w/Pufferfish_(item)",
         "price": "3",
         "stack": "64"
     },
@@ -131,7 +131,7 @@
         "material_id": "tropical_fish",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/ad/Tropical_Fish_JE2_BE2.png",
         "name": "tropical fish",
-        "url": "https://minecraft.fandom.com/wiki/Tropical_Fish_(item)",
+        "url": "https://minecraft.wiki/w/Tropical_Fish_(item)",
         "price": "3",
         "stack": "64"
     },
@@ -139,7 +139,7 @@
         "material_id": "apple",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/af/Apple_JE3_BE3.png",
         "name": "apple",
-        "url": "https://minecraft.fandom.com/wiki/Apple",
+        "url": "https://minecraft.wiki/w/Apple",
         "price": "10",
         "stack": "64"
     },
@@ -147,7 +147,7 @@
         "material_id": "golden_apple",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/54/Golden_Apple_JE2_BE2.png",
         "name": "golden apple",
-        "url": "https://minecraft.fandom.com/wiki/Golden_Apple",
+        "url": "https://minecraft.wiki/w/Golden_Apple",
         "price": "250",
         "stack": "64"
     },
@@ -155,7 +155,7 @@
         "material_id": "enchanted_golden_apple",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/ed/Enchanted_Golden_Apple_JE2_BE2.gif",
         "name": "enchanted golden apple",
-        "url": "https://minecraft.fandom.com/wiki/Enchanted_Golden_Apple",
+        "url": "https://minecraft.wiki/w/Enchanted_Golden_Apple",
         "price": "500",
         "stack": "64"
     },
@@ -163,7 +163,7 @@
         "material_id": "carrot",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/4e/Carrot_JE3_BE2.png",
         "name": "carrot",
-        "url": "https://minecraft.fandom.com/wiki/Carrot",
+        "url": "https://minecraft.wiki/w/Carrot",
         "price": "2",
         "stack": "64"
     },
@@ -171,7 +171,7 @@
         "material_id": "golden_carrot",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/aa/Golden_Carrot_JE4_BE2.png",
         "name": "golden carrot",
-        "url": "https://minecraft.fandom.com/wiki/Golden_Carrot",
+        "url": "https://minecraft.wiki/w/Golden_Carrot",
         "price": "40",
         "stack": "64"
     },
@@ -179,7 +179,7 @@
         "material_id": "potato",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c1/Potato_JE3_BE2.png",
         "name": "potato",
-        "url": "https://minecraft.fandom.com/wiki/Potato",
+        "url": "https://minecraft.wiki/w/Potato",
         "price": "2",
         "stack": "64"
     },
@@ -187,7 +187,7 @@
         "material_id": "baked_potato",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/e0/Baked_Potato_JE4_BE2.png",
         "name": "baked potato",
-        "url": "https://minecraft.fandom.com/wiki/Baked_Potato",
+        "url": "https://minecraft.wiki/w/Baked_Potato",
         "price": "3",
         "stack": "64"
     },
@@ -195,7 +195,7 @@
         "material_id": "melon",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/f0/Melon_JE2_BE2.png",
         "name": "melon",
-        "url": "https://minecraft.fandom.com/wiki/Melon",
+        "url": "https://minecraft.wiki/w/Melon",
         "price": "16",
         "stack": "64"
     },
@@ -203,7 +203,7 @@
         "material_id": "melon_slice",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/f2/Melon_Slice_JE2_BE2.png",
         "name": "melon slice",
-        "url": "https://minecraft.fandom.com/wiki/Melon_Slice",
+        "url": "https://minecraft.wiki/w/Melon_Slice",
         "price": "2",
         "stack": "64"
     },
@@ -211,7 +211,7 @@
         "material_id": "glistering_melon_slice",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/e7/Glistering_Melon_Slice_JE3_BE2.png",
         "name": "glistering melon slice",
-        "url": "https://minecraft.fandom.com/wiki/Glistering_Melon_Slice",
+        "url": "https://minecraft.wiki/w/Glistering_Melon_Slice",
         "price": "40",
         "stack": "64"
     },
@@ -219,7 +219,7 @@
         "material_id": "pumpkin",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/fc/Pumpkin_JE2_BE2.png",
         "name": "pumpkin",
-        "url": "https://minecraft.fandom.com/wiki/Pumpkin",
+        "url": "https://minecraft.wiki/w/Pumpkin",
         "price": "6",
         "stack": "64"
     },
@@ -227,7 +227,7 @@
         "material_id": "pumpkin_pie",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/ac/Pumpkin_Pie_JE2_BE2.png",
         "name": "pumpkin pie",
-        "url": "https://minecraft.fandom.com/wiki/Pumpkin_Pie",
+        "url": "https://minecraft.wiki/w/Pumpkin_Pie",
         "price": "-",
         "stack": "64"
     },
@@ -235,7 +235,7 @@
         "material_id": "beetroot",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/12/Beetroot_JE2_BE2.png",
         "name": "beetroot",
-        "url": "https://minecraft.fandom.com/wiki/Beetroot",
+        "url": "https://minecraft.wiki/w/Beetroot",
         "price": "1",
         "stack": "64"
     },
@@ -243,7 +243,7 @@
         "material_id": "egg",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/96/Egg_JE2_BE2.png",
         "name": "egg",
-        "url": "https://minecraft.fandom.com/wiki/Egg",
+        "url": "https://minecraft.wiki/w/Egg",
         "price": "2",
         "stack": "16"
     },
@@ -251,7 +251,7 @@
         "material_id": "milk",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/ca/Milk_Bucket_JE2_BE2.png",
         "name": "milk",
-        "url": "https://minecraft.fandom.com/wiki/Milk",
+        "url": "https://minecraft.wiki/w/Milk",
         "price": "60",
         "stack": "0"
     },
@@ -259,7 +259,7 @@
         "material_id": "cake",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c8/Cake_JE2.png",
         "name": "cake",
-        "url": "https://minecraft.fandom.com/wiki/Cake",
+        "url": "https://minecraft.wiki/w/Cake",
         "price": "?",
         "stack": "0"
     },
@@ -267,7 +267,7 @@
         "material_id": "fermented_spider_eye",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/85/Fermented_Spider_Eye_JE2_BE2.png",
         "name": "fermented spider eye",
-        "url": "https://minecraft.fandom.com/wiki/Fermented_Spider_Eye",
+        "url": "https://minecraft.wiki/w/Fermented_Spider_Eye",
         "price": "-",
         "stack": "64"
     },
@@ -275,7 +275,7 @@
         "material_id": "chorus_fruit",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/33/Chorus_Fruit_JE2_BE2.png",
         "name": "chorus fruit",
-        "url": "https://minecraft.fandom.com/wiki/Chorus_Fruit",
+        "url": "https://minecraft.wiki/w/Chorus_Fruit",
         "price": "5",
         "stack": "64"
     },
@@ -283,7 +283,7 @@
         "material_id": "popped_chorus_fruit",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7f/Popped_Chorus_Fruit_JE2_BE2.png",
         "name": "popped chorus fruit",
-        "url": "https://minecraft.fandom.com/wiki/Popped_Chorus_Fruit",
+        "url": "https://minecraft.wiki/w/Popped_Chorus_Fruit",
         "price": "6",
         "stack": "64"
     },
@@ -291,7 +291,7 @@
         "material_id": "bucket_of_cod",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7f/Bucket_of_Cod_JE2_BE2.png",
         "name": "bucket of cod",
-        "url": "https://minecraft.fandom.com/wiki/Bucket_of_Cod",
+        "url": "https://minecraft.wiki/w/Bucket_of_Cod",
         "price": "63",
         "stack": "0"
     },
@@ -299,7 +299,7 @@
         "material_id": "bucket_of_salmon",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/47/Bucket_of_Salmon_JE2_BE2.png",
         "name": "bucket of salmon",
-        "url": "https://minecraft.fandom.com/wiki/Bucket_of_Salmon",
+        "url": "https://minecraft.wiki/w/Bucket_of_Salmon",
         "price": "64",
         "stack": "0"
     },
@@ -307,7 +307,7 @@
         "material_id": "bucket_of_pufferfish",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/26/Bucket_of_Pufferfish_JE2_BE2.png",
         "name": "bucket of pufferfish",
-        "url": "https://minecraft.fandom.com/wiki/Bucket_of_Pufferfish",
+        "url": "https://minecraft.wiki/w/Bucket_of_Pufferfish",
         "price": "63",
         "stack": "0"
     },
@@ -315,7 +315,7 @@
         "material_id": "bucket_of_tropical_fish",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/90/Bucket_of_Tropical_Fish_JE3_BE2.png",
         "name": "bucket of tropical fish",
-        "url": "https://minecraft.fandom.com/wiki/Bucket_of_Tropical_Fish",
+        "url": "https://minecraft.wiki/w/Bucket_of_Tropical_Fish",
         "price": "63",
         "stack": "0"
     }

--- a/src/_data/ores.json
+++ b/src/_data/ores.json
@@ -3,7 +3,7 @@
         "material_id": "redstone_ore",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/3e/Redstone_Ore_JE2_BE2.png",
         "name": "redstone ore",
-        "url": "https://minecraft.fandom.com/wiki/Redstone_Ore",
+        "url": "https://minecraft.wiki/w/Redstone_Ore",
         "price": "30",
         "stack": "64"
     },
@@ -11,7 +11,7 @@
         "material_id": "redstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/e1/Redstone_Dust_JE2_BE2.png",
         "name": "redstone dust",
-        "url": "https://minecraft.fandom.com/wiki/Redstone_Dust",
+        "url": "https://minecraft.wiki/w/Redstone_Dust",
         "price": "3",
         "stack": "64"
     },
@@ -19,7 +19,7 @@
         "material_id": "redstone_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/26/Block_of_Redstone_JE2_BE2.png",
         "name": "block of redstone",
-        "url": "https://minecraft.fandom.com/wiki/Block_of_Redstone",
+        "url": "https://minecraft.wiki/w/Block_of_Redstone",
         "price": "27",
         "stack": "64"
     },
@@ -27,7 +27,7 @@
         "material_id": "coal_ore",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d6/Coal_Ore_JE2_BE2.png",
         "name": "coal ore",
-        "url": "https://minecraft.fandom.com/wiki/Coal_Ore",
+        "url": "https://minecraft.wiki/w/Coal_Ore",
         "price": "28",
         "stack": "64"
     },
@@ -35,7 +35,7 @@
         "material_id": "coal",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/58/Coal_JE4_BE3.png",
         "name": "coal",
-        "url": "https://minecraft.fandom.com/wiki/Coal",
+        "url": "https://minecraft.wiki/w/Coal",
         "price": "8",
         "stack": "64"
     },
@@ -43,7 +43,7 @@
         "material_id": "coal_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/cc/Block_of_Coal_JE3_BE2.png",
         "name": "block of coal",
-        "url": "https://minecraft.fandom.com/wiki/Block_of_Coal",
+        "url": "https://minecraft.wiki/w/Block_of_Coal",
         "price": "72",
         "stack": "64"
     },
@@ -51,7 +51,7 @@
         "material_id": "lapis_ore",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/ce/Lapis_Lazuli_Ore_JE2_BE2.png",
         "name": "lapis ore",
-        "url": "https://minecraft.fandom.com/wiki/Lapis_Lazuli_Ore",
+        "url": "https://minecraft.wiki/w/Lapis_Lazuli_Ore",
         "price": "100",
         "stack": "64"
     },
@@ -59,7 +59,7 @@
         "material_id": "lapis_lazuli",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/43/Lapis_Lazuli_JE2_BE2.png",
         "name": "lapis lazuli",
-        "url": "https://minecraft.fandom.com/wiki/Lapis_Lazuli",
+        "url": "https://minecraft.wiki/w/Lapis_Lazuli",
         "price": "5",
         "stack": "64"
     },
@@ -67,7 +67,7 @@
         "material_id": "lapis_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/55/Block_of_Lapis_Lazuli_JE3_BE3.png",
         "name": "lapis lazuli block",
-        "url": "https://minecraft.fandom.com/wiki/Lapis_Lazuli_Block",
+        "url": "https://minecraft.wiki/w/Lapis_Lazuli_Block",
         "price": "45",
         "stack": "64"
     },
@@ -75,7 +75,7 @@
         "material_id": "iron_ore",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/88/Iron_Ore_JE2_BE2.png",
         "name": "iron ore",
-        "url": "https://minecraft.fandom.com/wiki/Iron_Ore",
+        "url": "https://minecraft.wiki/w/Iron_Ore",
         "price": "18",
         "stack": "64"
     },
@@ -83,7 +83,7 @@
         "material_id": "iron_nugget",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/ea/Iron_Nugget_JE1_BE1.png",
         "name": "iron nugget",
-        "url": "https://minecraft.fandom.com/wiki/Iron_Nugget",
+        "url": "https://minecraft.wiki/w/Iron_Nugget",
         "price": "2",
         "stack": "64"
     },
@@ -91,7 +91,7 @@
         "material_id": "iron_ingot",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/fc/Iron_Ingot_JE3_BE2.png",
         "name": "iron ingot",
-        "url": "https://minecraft.fandom.com/wiki/Iron_Ingot",
+        "url": "https://minecraft.wiki/w/Iron_Ingot",
         "price": "20",
         "stack": "64"
     },
@@ -99,7 +99,7 @@
         "material_id": "iron_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7e/Block_of_Iron_JE4_BE3.png",
         "name": "block of iron",
-        "url": "https://minecraft.fandom.com/wiki/Block_of_Iron",
+        "url": "https://minecraft.wiki/w/Block_of_Iron",
         "price": "180",
         "stack": "64"
     },
@@ -107,7 +107,7 @@
         "material_id": "gold_ore",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/b9/Gold_Ore_JE3_BE2.png",
         "name": "gold ore",
-        "url": "https://minecraft.fandom.com/wiki/Gold_Ore",
+        "url": "https://minecraft.wiki/w/Gold_Ore",
         "price": "48",
         "stack": "64"
     },
@@ -115,7 +115,7 @@
         "material_id": "gold_nugget",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/3d/Gold_Nugget_JE3_BE2.png",
         "name": "gold nugget",
-        "url": "https://minecraft.fandom.com/wiki/Gold_Nugget",
+        "url": "https://minecraft.wiki/w/Gold_Nugget",
         "price": "5",
         "stack": "64"
     },
@@ -123,7 +123,7 @@
         "material_id": "gold_ingot",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/8a/Gold_Ingot_JE4_BE2.png",
         "name": "gold ingot",
-        "url": "https://minecraft.fandom.com/wiki/Gold_Ingot",
+        "url": "https://minecraft.wiki/w/Gold_Ingot",
         "price": "50",
         "stack": "64"
     },
@@ -131,7 +131,7 @@
         "material_id": "gold_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/72/Block_of_Gold_JE6_BE3.png",
         "name": "block of gold",
-        "url": "https://minecraft.fandom.com/wiki/Block_of_Gold",
+        "url": "https://minecraft.wiki/w/Block_of_Gold",
         "price": "450",
         "stack": "64"
     },
@@ -139,7 +139,7 @@
         "material_id": "emerald_ore",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/54/Emerald_Ore_JE3_BE2.png",
         "name": "emerald ore",
-        "url": "https://minecraft.fandom.com/wiki/Emerald_Ore",
+        "url": "https://minecraft.wiki/w/Emerald_Ore",
         "price": "300",
         "stack": "64"
     },
@@ -147,7 +147,7 @@
         "material_id": "emerald",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/26/Emerald_JE3_BE3.png",
         "name": "emerald",
-        "url": "https://minecraft.fandom.com/wiki/Emerald",
+        "url": "https://minecraft.wiki/w/Emerald",
         "price": "100",
         "stack": "64"
     },
@@ -155,7 +155,7 @@
         "material_id": "emerald_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/0b/Block_of_Emerald_JE4_BE3.png",
         "name": "block of emerald",
-        "url": "https://minecraft.fandom.com/wiki/Block_of_Emerald",
+        "url": "https://minecraft.wiki/w/Block_of_Emerald",
         "price": "900",
         "stack": "64"
     },
@@ -163,7 +163,7 @@
         "material_id": "diamond_ore",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/b5/Diamond_Ore_JE3_BE3.png",
         "name": "diamond ore",
-        "url": "https://minecraft.fandom.com/wiki/Diamond_Ore",
+        "url": "https://minecraft.wiki/w/Diamond_Ore",
         "price": "875",
         "stack": "64"
     },
@@ -171,7 +171,7 @@
         "material_id": "diamond",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/ab/Diamond_JE3_BE3.png",
         "name": "diamond",
-        "url": "https://minecraft.fandom.com/wiki/Diamond",
+        "url": "https://minecraft.wiki/w/Diamond",
         "price": "250",
         "stack": "64"
     },
@@ -179,7 +179,7 @@
         "material_id": "diamond_block",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c8/Block_of_Diamond_JE5_BE3.png",
         "name": "block of diamond",
-        "url": "https://minecraft.fandom.com/wiki/Block_of_Diamond",
+        "url": "https://minecraft.wiki/w/Block_of_Diamond",
         "price": "2250",
         "stack": "64"
     }

--- a/src/_data/sand.json
+++ b/src/_data/sand.json
@@ -3,7 +3,7 @@
         "material_id": "sand",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/71/Sand_JE5_BE3.png",
         "name": "sand",
-        "url": "https://minecraft.fandom.com/wiki/Sand",
+        "url": "https://minecraft.wiki/w/Sand",
         "price": "1",
         "stack": "64"
     },
@@ -11,7 +11,7 @@
         "material_id": "sandstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/95/Sandstone_JE6_BE3.png",
         "name": "sandstone",
-        "url": "https://minecraft.fandom.com/wiki/Sandstone",
+        "url": "https://minecraft.wiki/w/Sandstone",
         "price": "4",
         "stack": "64"
     },
@@ -19,7 +19,7 @@
         "material_id": "sandstone_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/ff/Sandstone_Slab_JE5_BE2.png",
         "name": "sandstone slab",
-        "url": "https://minecraft.fandom.com/wiki/Sandstone_Slab",
+        "url": "https://minecraft.wiki/w/Sandstone_Slab",
         "price": "2",
         "stack": "64"
     },
@@ -27,7 +27,7 @@
         "material_id": "sandstone_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/8e/Sandstone_Stairs_%28N%29_JE6_BE3.png",
         "name": "sandstone stairs",
-        "url": "https://minecraft.fandom.com/wiki/Sandstone_Stairs",
+        "url": "https://minecraft.wiki/w/Sandstone_Stairs",
         "price": "6",
         "stack": "64"
     },
@@ -35,7 +35,7 @@
         "material_id": "sandstone_wall",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/bc/Sandstone_Wall_JE2_BE1.png",
         "name": "sandstone wall",
-        "url": "https://minecraft.fandom.com/wiki/Sandstone_Wall",
+        "url": "https://minecraft.wiki/w/Sandstone_Wall",
         "price": "4",
         "stack": "64"
     },
@@ -43,7 +43,7 @@
         "material_id": "cut_sandstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/91/Cut_Sandstone_JE5_BE2.png",
         "name": "cut sandstone",
-        "url": "https://minecraft.fandom.com/wiki/Cut_Sandstone",
+        "url": "https://minecraft.wiki/w/Cut_Sandstone",
         "price": "4",
         "stack": "64"
     },
@@ -51,7 +51,7 @@
         "material_id": "cut_sandstone_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/37/Cut_Sandstone_Slab_JE1_BE1.png",
         "name": "cut sandstone slab",
-        "url": "https://minecraft.fandom.com/wiki/Cut_Sandstone_Slab",
+        "url": "https://minecraft.wiki/w/Cut_Sandstone_Slab",
         "price": "2",
         "stack": "64"
     },
@@ -59,7 +59,7 @@
         "material_id": "chiseled_sandstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d9/Chiseled_Sandstone_JE5_BE2.png",
         "name": "chiseled sandstone",
-        "url": "https://minecraft.fandom.com/wiki/Chiseled_Sandstone",
+        "url": "https://minecraft.wiki/w/Chiseled_Sandstone",
         "price": "4",
         "stack": "64"
     },
@@ -67,7 +67,7 @@
         "material_id": "smooth_sandstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/3c/Smooth_Sandstone.png",
         "name": "smooth sandstone",
-        "url": "https://minecraft.fandom.com/wiki/Smooth_Sandstone",
+        "url": "https://minecraft.wiki/w/Smooth_Sandstone",
         "price": "5",
         "stack": "64"
     },
@@ -75,7 +75,7 @@
         "material_id": "smooth_sandstone_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/86/Smooth_Sandstone_Slab_JE3_BE2.png",
         "name": "smooth sandstone slab",
-        "url": "https://minecraft.fandom.com/wiki/Smooth_Sandstone_Slab",
+        "url": "https://minecraft.wiki/w/Smooth_Sandstone_Slab",
         "price": "3",
         "stack": "64"
     },
@@ -83,7 +83,7 @@
         "material_id": "smooth_sandstone_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/47/Smooth_Sandstone_Stairs_%28N%29_JE4_BE2.png",
         "name": "smooth sandstone stairs",
-        "url": "https://minecraft.fandom.com/wiki/Smooth_Sandstone_Stairs",
+        "url": "https://minecraft.wiki/w/Smooth_Sandstone_Stairs",
         "price": "7",
         "stack": "64"
     },
@@ -91,7 +91,7 @@
         "material_id": "red_sand",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/36/Red_Sand_JE3_BE2.png",
         "name": "red sand",
-        "url": "https://minecraft.fandom.com/wiki/Red_Sand",
+        "url": "https://minecraft.wiki/w/Red_Sand",
         "price": "1",
         "stack": "64"
     },
@@ -99,7 +99,7 @@
         "material_id": "red_sandstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/47/Red_Sandstone_JE4_BE2.png",
         "name": "red sandstone",
-        "url": "https://minecraft.fandom.com/wiki/Red_Sandstone",
+        "url": "https://minecraft.wiki/w/Red_Sandstone",
         "price": "4",
         "stack": "64"
     },
@@ -107,7 +107,7 @@
         "material_id": "red_sandstone_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/08/Red_Sandstone_Slab_JE4_BE2.png",
         "name": "red sandstone slab",
-        "url": "https://minecraft.fandom.com/wiki/Red_Sandstone_Slab",
+        "url": "https://minecraft.wiki/w/Red_Sandstone_Slab",
         "price": "2",
         "stack": "64"
     },
@@ -115,7 +115,7 @@
         "material_id": "red_sandstone_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/6/60/Red_Sandstone_Stairs_%28N%29_JE4_BE2.png",
         "name": "red sandstone stairs",
-        "url": "https://minecraft.fandom.com/wiki/Red_Sandstone_Stairs",
+        "url": "https://minecraft.wiki/w/Red_Sandstone_Stairs",
         "price": "6",
         "stack": "64"
     },
@@ -123,7 +123,7 @@
         "material_id": "red_sandstone_wall",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/01/Red_Sandstone_Wall_JE2_BE1.png",
         "name": "red sandstone wall",
-        "url": "https://minecraft.fandom.com/wiki/Red_Sandstone_Wall",
+        "url": "https://minecraft.wiki/w/Red_Sandstone_Wall",
         "price": "4",
         "stack": "64"
     },
@@ -131,7 +131,7 @@
         "material_id": "cut_red_sandstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/36/Cut_Red_Sandstone_JE4_BE2.png",
         "name": "cut red sandstone",
-        "url": "https://minecraft.fandom.com/wiki/Cut_Red_Sandstone",
+        "url": "https://minecraft.wiki/w/Cut_Red_Sandstone",
         "price": "4",
         "stack": "64"
     },
@@ -139,7 +139,7 @@
         "material_id": "cut_red_sandstone_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/0a/Cut_Red_Sandstone_Slab_JE1_BE1.png",
         "name": "cut red sandstone slab",
-        "url": "https://minecraft.fandom.com/wiki/Cut_Red_Sandstone_Slab",
+        "url": "https://minecraft.wiki/w/Cut_Red_Sandstone_Slab",
         "price": "2",
         "stack": "64"
     },
@@ -147,7 +147,7 @@
         "material_id": "chiseled_red_sandstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1c/Chiseled_Red_Sandstone_JE4_BE2.png",
         "name": "chiseled red sandstone",
-        "url": "https://minecraft.fandom.com/wiki/Chiseled_Red_Sandstone",
+        "url": "https://minecraft.wiki/w/Chiseled_Red_Sandstone",
         "price": "4",
         "stack": "64"
     },
@@ -155,7 +155,7 @@
         "material_id": "smooth_red_sandstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d3/Smooth_Red_Sandstone.png",
         "name": "smooth red sandstone",
-        "url": "https://minecraft.fandom.com/wiki/Smooth_Red_Sandstone",
+        "url": "https://minecraft.wiki/w/Smooth_Red_Sandstone",
         "price": "5",
         "stack": "64"
     },
@@ -163,7 +163,7 @@
         "material_id": "smooth_red_sandstone_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/56/Smooth_Red_Sandstone_Slab_JE3_BE2.png",
         "name": "smooth red sandstone slab",
-        "url": "https://minecraft.fandom.com/wiki/Smooth_Red_Sandstone_Slab",
+        "url": "https://minecraft.wiki/w/Smooth_Red_Sandstone_Slab",
         "price": "3",
         "stack": "64"
     },
@@ -171,7 +171,7 @@
         "material_id": "smooth_red_sandstone_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/22/Smooth_Red_Sandstone_Stairs_%28N%29_JE3_BE1.png",
         "name": "smooth red sandstone stairs",
-        "url": "https://minecraft.fandom.com/wiki/Smooth_Red_Sandstone_Stairs",
+        "url": "https://minecraft.wiki/w/Smooth_Red_Sandstone_Stairs",
         "price": "7",
         "stack": "64"
     }

--- a/src/_data/stone.json
+++ b/src/_data/stone.json
@@ -3,7 +3,7 @@
         "material_id": "cobblestone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/6/67/Cobblestone.png",
         "name": "cobblestone",
-        "url": "https://minecraft.fandom.com/wiki/Cobblestone",
+        "url": "https://minecraft.wiki/w/Cobblestone",
         "price": "1",
         "stack": "64"
     },
@@ -11,7 +11,7 @@
         "material_id": "cobblestone_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/f5/Cobblestone_Slab_JE4_BE3.png",
         "name": "cobblestone slab",
-        "url": "https://minecraft.fandom.com/wiki/Cobblestone_Slab",
+        "url": "https://minecraft.wiki/w/Cobblestone_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -19,7 +19,7 @@
         "material_id": "cobblestone_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/94/Cobblestone_Stairs_%28N%29_JE6_BE6.png",
         "name": "cobblestone stairs",
-        "url": "https://minecraft.fandom.com/wiki/Cobblestone_Stairs",
+        "url": "https://minecraft.wiki/w/Cobblestone_Stairs",
         "price": "2",
         "stack": "64"
     },
@@ -27,7 +27,7 @@
         "material_id": "cobblestone_wall",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/0f/Cobblestone_Wall_JE2_BE2.png",
         "name": "cobblestone wall",
-        "url": "https://minecraft.fandom.com/wiki/Cobblestone_Wall",
+        "url": "https://minecraft.wiki/w/Cobblestone_Wall",
         "price": "1",
         "stack": "64"
     },
@@ -35,7 +35,7 @@
         "material_id": "stone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d4/Stone.png",
         "name": "stone",
-        "url": "https://minecraft.fandom.com/wiki/Stone",
+        "url": "https://minecraft.wiki/w/Stone",
         "price": "2",
         "stack": "64"
     },
@@ -43,7 +43,7 @@
         "material_id": "stone_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d4/Stone_Slab_JE2_BE1.png",
         "name": "stone slab",
-        "url": "https://minecraft.fandom.com/wiki/Stone_Slab",
+        "url": "https://minecraft.wiki/w/Stone_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -51,7 +51,7 @@
         "material_id": "stone_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/5c/Stone_Stairs_%28N%29_JE2_BE2.png",
         "name": "stone stairs",
-        "url": "https://minecraft.fandom.com/wiki/Stone_Stairs",
+        "url": "https://minecraft.wiki/w/Stone_Stairs",
         "price": "3",
         "stack": "64"
     },
@@ -59,7 +59,7 @@
         "material_id": "smooth_stone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d8/Smooth_Stone_JE2_BE2.png",
         "name": "smooth stone",
-        "url": "https://minecraft.fandom.com/wiki/Smooth_Stone",
+        "url": "https://minecraft.wiki/w/Smooth_Stone",
         "price": "3",
         "stack": "64"
     },
@@ -67,7 +67,7 @@
         "material_id": "smooth_stone_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/05/Smooth_Stone_Slab_JE2_BE2.png",
         "name": "smooth stone slab",
-        "url": "https://minecraft.fandom.com/wiki/Smooth_Stone_Slab",
+        "url": "https://minecraft.wiki/w/Smooth_Stone_Slab",
         "price": "2",
         "stack": "64"
     },
@@ -75,7 +75,7 @@
         "material_id": "andesite",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/28/Andesite_JE3_BE2.png",
         "name": "andesite",
-        "url": "https://minecraft.fandom.com/wiki/Andesite",
+        "url": "https://minecraft.wiki/w/Andesite",
         "price": "1",
         "stack": "64"
     },
@@ -83,7 +83,7 @@
         "material_id": "andesite_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/77/Andesite_Slab_JE2_BE2.png",
         "name": "andesite slab",
-        "url": "https://minecraft.fandom.com/wiki/Andesite_Slab",
+        "url": "https://minecraft.wiki/w/Andesite_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -91,7 +91,7 @@
         "material_id": "andesite_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/e0/Andesite_Stairs_%28N%29_JE2_BE1.png",
         "name": "andesite stairs",
-        "url": "https://minecraft.fandom.com/wiki/Andesite_Stairs",
+        "url": "https://minecraft.wiki/w/Andesite_Stairs",
         "price": "2",
         "stack": "64"
     },
@@ -99,7 +99,7 @@
         "material_id": "andesite_wall",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/4b/Andesite_Wall_JE2_BE1.png",
         "name": "andesite wall",
-        "url": "https://minecraft.fandom.com/wiki/Andesite_Wall",
+        "url": "https://minecraft.wiki/w/Andesite_Wall",
         "price": "1",
         "stack": "64"
     },
@@ -107,7 +107,7 @@
         "material_id": "polished_andesite",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/21/Polished_Andesite_JE2_BE2.png",
         "name": "polished andesite",
-        "url": "https://minecraft.fandom.com/wiki/Polished_Andesite",
+        "url": "https://minecraft.wiki/w/Polished_Andesite",
         "price": "1",
         "stack": "64"
     },
@@ -115,7 +115,7 @@
         "material_id": "polished_andesite_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/f2/Polished_Andesite_Slab_JE2_BE2.png",
         "name": "polished andesite slab",
-        "url": "https://minecraft.fandom.com/wiki/Polished_Andesite_Slab",
+        "url": "https://minecraft.wiki/w/Polished_Andesite_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -123,7 +123,7 @@
         "material_id": "polished_andesite_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/0d/Polished_Andesite_Stairs_%28N%29_JE2_BE1.png",
         "name": "polished andesite stairs",
-        "url": "https://minecraft.fandom.com/wiki/Polished_Andesite_Stairs",
+        "url": "https://minecraft.wiki/w/Polished_Andesite_Stairs",
         "price": "2",
         "stack": "64"
     },
@@ -131,7 +131,7 @@
         "material_id": "diorite",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d7/Diorite_JE4_BE3.png",
         "name": "diorite",
-        "url": "https://minecraft.fandom.com/wiki/Diorite",
+        "url": "https://minecraft.wiki/w/Diorite",
         "price": "1",
         "stack": "64"
     },
@@ -139,7 +139,7 @@
         "material_id": "diorite_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/9f/Diorite_Slab_JE3_BE2.png",
         "name": "diorite slab",
-        "url": "https://minecraft.fandom.com/wiki/Diorite_Slab",
+        "url": "https://minecraft.wiki/w/Diorite_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -147,7 +147,7 @@
         "material_id": "diorite_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/9a/Diorite_Stairs_%28N%29_JE3_BE2.png",
         "name": "diorite stairs",
-        "url": "https://minecraft.fandom.com/wiki/Diorite_Stairs",
+        "url": "https://minecraft.wiki/w/Diorite_Stairs",
         "price": "2",
         "stack": "64"
     },
@@ -155,7 +155,7 @@
         "material_id": "diorite_wall",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/a4/Diorite_Wall_JE3_BE1.png",
         "name": "diorite wall",
-        "url": "https://minecraft.fandom.com/wiki/Diorite_Wall",
+        "url": "https://minecraft.wiki/w/Diorite_Wall",
         "price": "1",
         "stack": "64"
     },
@@ -163,7 +163,7 @@
         "material_id": "polished_diorite",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/a8/Polished_Diorite_JE2_BE2.png",
         "name": "polished diorite",
-        "url": "https://minecraft.fandom.com/wiki/Polished_Diorite",
+        "url": "https://minecraft.wiki/w/Polished_Diorite",
         "price": "1",
         "stack": "64"
     },
@@ -171,7 +171,7 @@
         "material_id": "polished_diorite_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/af/Polished_Diorite_Slab_JE2_BE2.png",
         "name": "polished diorite slab",
-        "url": "https://minecraft.fandom.com/wiki/Polished_Diorite_Slab",
+        "url": "https://minecraft.wiki/w/Polished_Diorite_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -179,7 +179,7 @@
         "material_id": "polished_diorite_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/06/Polished_Diorite_Stairs_%28N%29_JE2_BE2.png",
         "name": "polished diorite stairs",
-        "url": "https://minecraft.fandom.com/wiki/Polished_Diorite_Stairs",
+        "url": "https://minecraft.wiki/w/Polished_Diorite_Stairs",
         "price": "2",
         "stack": "64"
     },
@@ -187,7 +187,7 @@
         "material_id": "granite",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7e/Granite_JE2_BE2.png",
         "name": "granite",
-        "url": "https://minecraft.fandom.com/wiki/Granite",
+        "url": "https://minecraft.wiki/w/Granite",
         "price": "1",
         "stack": "64"
     },
@@ -195,7 +195,7 @@
         "material_id": "granite_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/cd/Granite_Slab_JE1_BE1.png",
         "name": "granite slab",
-        "url": "https://minecraft.fandom.com/wiki/Granite_Slab",
+        "url": "https://minecraft.wiki/w/Granite_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -203,7 +203,7 @@
         "material_id": "granite_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7f/Granite_Stairs_%28N%29_JE1_BE1.png",
         "name": "granite stairs",
-        "url": "https://minecraft.fandom.com/wiki/Granite_Stairs",
+        "url": "https://minecraft.wiki/w/Granite_Stairs",
         "price": "2",
         "stack": "64"
     },
@@ -211,7 +211,7 @@
         "material_id": "granite_wall",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/59/Granite_Wall_JE1_BE1.png",
         "name": "granite wall",
-        "url": "https://minecraft.fandom.com/wiki/Granite_Wall",
+        "url": "https://minecraft.wiki/w/Granite_Wall",
         "price": "1",
         "stack": "64"
     },
@@ -219,7 +219,7 @@
         "material_id": "polished_granite",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c5/Polished_Granite_JE2_BE2.png",
         "name": "polished granite",
-        "url": "https://minecraft.fandom.com/wiki/Polished_Granite",
+        "url": "https://minecraft.wiki/w/Polished_Granite",
         "price": "1",
         "stack": "64"
     },
@@ -227,7 +227,7 @@
         "material_id": "polished_granite_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/39/Polished_Granite_Slab_JE1_BE1.png",
         "name": "polished granite slab",
-        "url": "https://minecraft.fandom.com/wiki/Polished_Granite_Slab",
+        "url": "https://minecraft.wiki/w/Polished_Granite_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -235,7 +235,7 @@
         "material_id": "polished_granite_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/35/Polished_Granite_Stairs_%28N%29_JE1_BE1.png",
         "name": "polished granite stairs",
-        "url": "https://minecraft.fandom.com/wiki/Polished_Granite_Stairs",
+        "url": "https://minecraft.wiki/w/Polished_Granite_Stairs",
         "price": "2",
         "stack": "64"
     },
@@ -243,7 +243,7 @@
         "material_id": "clay",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/42/Clay_JE2_BE2.png",
         "name": "clay",
-        "url": "https://minecraft.fandom.com/wiki/Clay",
+        "url": "https://minecraft.wiki/w/Clay",
         "price": "12",
         "stack": "64"
     },
@@ -251,7 +251,7 @@
         "material_id": "clay_ball",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/71/Clay_Ball_JE2_BE2.png",
         "name": "clay ball",
-        "url": "https://minecraft.fandom.com/wiki/Clay_Ball",
+        "url": "https://minecraft.wiki/w/Clay_Ball",
         "price": "3",
         "stack": "64"
     },
@@ -259,7 +259,7 @@
         "material_id": "brick",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/32/Brick_JE2_BE2.png",
         "name": "brick",
-        "url": "https://minecraft.fandom.com/wiki/Brick",
+        "url": "https://minecraft.wiki/w/Brick",
         "price": "4",
         "stack": "64"
     },
@@ -267,7 +267,7 @@
         "material_id": "bricks",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/6/62/Bricks_JE5_BE3.png",
         "name": "bricks",
-        "url": "https://minecraft.fandom.com/wiki/Bricks",
+        "url": "https://minecraft.wiki/w/Bricks",
         "price": "16",
         "stack": "64"
     },
@@ -275,7 +275,7 @@
         "material_id": "brick_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/25/Brick_Slab_JE3_BE2.png",
         "name": "brick slab",
-        "url": "https://minecraft.fandom.com/wiki/Brick_Slab",
+        "url": "https://minecraft.wiki/w/Brick_Slab",
         "price": "8",
         "stack": "64"
     },
@@ -283,7 +283,7 @@
         "material_id": "brick_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/25/Brick_Stairs_%28N%29_JE5_BE2.png",
         "name": "brick stairs",
-        "url": "https://minecraft.fandom.com/wiki/Brick_Stairs",
+        "url": "https://minecraft.wiki/w/Brick_Stairs",
         "price": "24",
         "stack": "64"
     },
@@ -291,7 +291,7 @@
         "material_id": "brick_wall",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c2/Brick_Wall_JE1_BE1.png",
         "name": "brick wall",
-        "url": "https://minecraft.fandom.com/wiki/Brick_Wall",
+        "url": "https://minecraft.wiki/w/Brick_Wall",
         "price": "16",
         "stack": "64"
     }

--- a/src/_data/utility.json
+++ b/src/_data/utility.json
@@ -3,7 +3,7 @@
         "material_id": "lantern",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7a/Lantern_JE1_BE1.gif",
         "name": "lantern",
-        "url": "https://minecraft.fandom.com/wiki/Lantern",
+        "url": "https://minecraft.wiki/w/Lantern",
         "price": "18",
         "stack": "64"
     },
@@ -11,7 +11,7 @@
         "material_id": "soul_lantern",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1b/Soul_Lantern_JE2_BE1.gif",
         "name": "soul lantern",
-        "url": "https://minecraft.fandom.com/wiki/Soul_Lantern",
+        "url": "https://minecraft.wiki/w/Soul_Lantern",
         "price": "-",
         "stack": "64"
     },
@@ -19,7 +19,7 @@
         "material_id": "torch",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/90/Torch.gif",
         "name": "torch",
-        "url": "https://minecraft.fandom.com/wiki/Torch",
+        "url": "https://minecraft.wiki/w/Torch",
         "price": "2",
         "stack": "64"
     },
@@ -27,7 +27,7 @@
         "material_id": "soul_torch",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1a/Soul_Torch_BE1.gif",
         "name": "soul torch",
-        "url": "https://minecraft.fandom.com/wiki/Soul_Torch",
+        "url": "https://minecraft.wiki/w/Soul_Torch",
         "price": "-",
         "stack": "64"
     },
@@ -35,7 +35,7 @@
         "material_id": "flint",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/97/Flint_JE3_BE3.png",
         "name": "flint",
-        "url": "https://minecraft.fandom.com/wiki/Flint",
+        "url": "https://minecraft.wiki/w/Flint",
         "price": "2",
         "stack": "64"
     },
@@ -43,7 +43,7 @@
         "material_id": "chest",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/41/Chest.gif",
         "name": "chest",
-        "url": "https://minecraft.fandom.com/wiki/Chest",
+        "url": "https://minecraft.wiki/w/Chest",
         "price": "16",
         "stack": "64"
     },
@@ -51,7 +51,7 @@
         "material_id": "lead",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1f/Lead_JE2_BE2.png",
         "name": "lead",
-        "url": "https://minecraft.fandom.com/wiki/Lead",
+        "url": "https://minecraft.wiki/w/Lead",
         "price": "18",
         "stack": "64"
     },
@@ -59,7 +59,7 @@
         "material_id": "name_tag",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/05/Name_Tag_JE2_BE2.png",
         "name": "nametag",
-        "url": "https://minecraft.fandom.com/wiki/Name_Tag",
+        "url": "https://minecraft.wiki/w/Name_Tag",
         "price": "50",
         "stack": "64"
     },
@@ -67,7 +67,7 @@
         "material_id": "paper",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/f2/Paper_JE2_BE2.png",
         "name": "paper",
-        "url": "https://minecraft.fandom.com/wiki/Paper",
+        "url": "https://minecraft.wiki/w/Paper",
         "price": "-",
         "stack": "64"
     },
@@ -75,7 +75,7 @@
         "material_id": "saddle",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/ba/Saddle_JE2_BE2.png",
         "name": "saddle",
-        "url": "https://minecraft.fandom.com/wiki/Saddle",
+        "url": "https://minecraft.wiki/w/Saddle",
         "price": "200",
         "stack": "64"
     },
@@ -83,7 +83,7 @@
         "material_id": "scaffolding",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/ce/Standing_Scaffolding_BE2.png",
         "name": "scaffolding",
-        "url": "https://minecraft.fandom.com/wiki/Scaffolding",
+        "url": "https://minecraft.wiki/w/Scaffolding",
         "price": "-",
         "stack": "64"
     },
@@ -91,7 +91,7 @@
         "material_id": "tnt",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/a2/TNT_JE3_BE2.png",
         "name": "tnt",
-        "url": "https://minecraft.fandom.com/wiki/TNT",
+        "url": "https://minecraft.wiki/w/TNT",
         "price": "54",
         "stack": "64"
     },
@@ -99,7 +99,7 @@
         "material_id": "bucket",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/fc/Bucket_JE2_BE2.png",
         "name": "bucket",
-        "url": "https://minecraft.fandom.com/wiki/Bucket",
+        "url": "https://minecraft.wiki/w/Bucket",
         "price": "60",
         "stack": "16"
     },
@@ -107,7 +107,7 @@
         "material_id": "lava_bucket",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/74/Lava_Bucket_JE2_BE2.png",
         "name": "lava bucket",
-        "url": "https://minecraft.fandom.com/wiki/Lava_Bucket",
+        "url": "https://minecraft.wiki/w/Lava_Bucket",
         "price": "62",
         "stack": "0"
     },
@@ -115,7 +115,7 @@
         "material_id": "totem_of_undying",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/2e/Totem_of_Undying_JE2_BE2.png",
         "name": "totem of undying",
-        "url": "https://minecraft.fandom.com/wiki/Totem_of_Undying",
+        "url": "https://minecraft.wiki/w/Totem_of_Undying",
         "price": "500",
         "stack": "0"
     },
@@ -123,7 +123,7 @@
         "material_id": "crafting_table",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/b7/Crafting_Table_JE4_BE3.png",
         "name": "crafting table",
-        "url": "https://minecraft.fandom.com/wiki/Crafting_Table",
+        "url": "https://minecraft.wiki/w/Crafting_Table",
         "price": "8",
         "stack": "64"
     },
@@ -131,7 +131,7 @@
         "material_id": "lectern",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/30/Lectern_Book_JE1_BE1.png",
         "name": "lectern",
-        "url": "https://minecraft.fandom.com/wiki/Lectern",
+        "url": "https://minecraft.wiki/w/Lectern",
         "price": "-",
         "stack": "64"
     },
@@ -139,7 +139,7 @@
         "material_id": "grindstone",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/e2/Grindstone_JE2_BE2.png",
         "name": "grindstone",
-        "url": "https://minecraft.fandom.com/wiki/Grindstone",
+        "url": "https://minecraft.wiki/w/Grindstone",
         "price": "8",
         "stack": "64"
     },
@@ -147,7 +147,7 @@
         "material_id": "blast_furnace",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/22/Blast_Furnace_%28S%29_JE1.png",
         "name": "blast furnace",
-        "url": "https://minecraft.fandom.com/wiki/Blast_Furnace",
+        "url": "https://minecraft.wiki/w/Blast_Furnace",
         "price": "116",
         "stack": "64"
     },
@@ -155,7 +155,7 @@
         "material_id": "smoker",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/a6/Smoker_%28S%29_JE1.png",
         "name": "smoker",
-        "url": "https://minecraft.fandom.com/wiki/Smoker",
+        "url": "https://minecraft.wiki/w/Smoker",
         "price": "36",
         "stack": "64"
     },
@@ -163,7 +163,7 @@
         "material_id": "fletching_table",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/17/Fletching_Table_JE2_BE1.png",
         "name": "fletching table",
-        "url": "https://minecraft.fandom.com/wiki/Fletching_Table",
+        "url": "https://minecraft.wiki/w/Fletching_Table",
         "price": "12",
         "stack": "64"
     },
@@ -171,7 +171,7 @@
         "material_id": "cartography_table",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d1/Cartography_Table_JE2_BE1.png",
         "name": "cartography table",
-        "url": "https://minecraft.fandom.com/wiki/Cartography_Table",
+        "url": "https://minecraft.wiki/w/Cartography_Table",
         "price": "-",
         "stack": "64"
     },
@@ -179,7 +179,7 @@
         "material_id": "brewing_stand",
         "image": "https://gamepedia.cursecdn.com/minecraft_gamepedia/f/fa/Brewing_Stand.png",
         "name": "brewing stand",
-        "url": "https://minecraft.fandom.com/wiki/Brewing_Stand",
+        "url": "https://minecraft.wiki/w/Brewing_Stand",
         "price": "53",
         "stack": "64"
     },
@@ -187,7 +187,7 @@
         "material_id": "smithing_table",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/93/Smithing_Table_JE2_BE2.png",
         "name": "smithing table",
-        "url": "https://minecraft.fandom.com/wiki/Smithing_Table",
+        "url": "https://minecraft.wiki/w/Smithing_Table",
         "price": "48",
         "stack": "64"
     },
@@ -195,7 +195,7 @@
         "material_id": "cauldron",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c9/Cauldron_JE7.png",
         "name": "cauldron",
-        "url": "https://minecraft.fandom.com/wiki/Cauldron",
+        "url": "https://minecraft.wiki/w/Cauldron",
         "price": "140",
         "stack": "64"
     },
@@ -203,7 +203,7 @@
         "material_id": "barrel",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/21/Barrel_%28U%29_JE1_BE1.png",
         "name": "barrel",
-        "url": "https://minecraft.fandom.com/wiki/Barrel",
+        "url": "https://minecraft.wiki/w/Barrel",
         "price": "14",
         "stack": "64"
     },
@@ -211,7 +211,7 @@
         "material_id": "loom",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d7/Loom_%28S%29_JE1_BE1.png",
         "name": "loom",
-        "url": "https://minecraft.fandom.com/wiki/Loom",
+        "url": "https://minecraft.wiki/w/Loom",
         "price": "8",
         "stack": "64"
     },
@@ -219,7 +219,7 @@
         "material_id": "stonecutter",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/9/93/Stonecutter_JE2_BE1.gif",
         "name": "stonecutter",
-        "url": "https://minecraft.fandom.com/wiki/Stonecutter",
+        "url": "https://minecraft.wiki/w/Stonecutter",
         "price": "26",
         "stack": "64"
     },
@@ -227,7 +227,7 @@
         "material_id": "composter",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1d/Composter_JE1.png",
         "name": "composter",
-        "url": "https://minecraft.fandom.com/wiki/Composter",
+        "url": "https://minecraft.wiki/w/Composter",
         "price": "8",
         "stack": "64"
     }

--- a/src/_data/wood.json
+++ b/src/_data/wood.json
@@ -3,7 +3,7 @@
         "material_id": "oak_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/e9/Oak_Log_%28UD%29_JE5_BE3.png",
         "name": "oak log",
-        "url": "https://minecraft.fandom.com/wiki/Oak_Log",
+        "url": "https://minecraft.wiki/w/Oak_Log",
         "price": "8",
         "stack": "64"
     },
@@ -11,7 +11,7 @@
         "material_id": "stripped_oak_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/eb/Stripped_Oak_Log_%28UD%29_JE2_BE2.png",
         "name": "stripped oak log",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Oak_Log",
+        "url": "https://minecraft.wiki/w/Stripped_Oak_Log",
         "price": "8",
         "stack": "64"
     },
@@ -19,7 +19,7 @@
         "material_id": "oak_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1d/Oak_Wood_%28UD%29_JE5_BE2.png",
         "name": "oak wood",
-        "url": "https://minecraft.fandom.com/wiki/Oak_Wood",
+        "url": "https://minecraft.wiki/w/Oak_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -27,7 +27,7 @@
         "material_id": "stripped_oak_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/6/60/Stripped_Oak_Wood_%28UD%29_JE1_BE1.png",
         "name": "stripped oak wood",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Oak_Wood",
+        "url": "https://minecraft.wiki/w/Stripped_Oak_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -35,7 +35,7 @@
         "material_id": "oak_planks",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/37/Oak_Planks_JE6_BE3.png",
         "name": "oak planks",
-        "url": "https://minecraft.fandom.com/wiki/Oak_Planks",
+        "url": "https://minecraft.wiki/w/Oak_Planks",
         "price": "2",
         "stack": "64"
     },
@@ -43,7 +43,7 @@
         "material_id": "oak_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/a0/Oak_Stairs_%28N%29_JE7_BE6.png",
         "name": "oak stairs",
-        "url": "https://minecraft.fandom.com/wiki/Oak_Stairs",
+        "url": "https://minecraft.wiki/w/Oak_Stairs",
         "price": "3",
         "stack": "64"
     },
@@ -51,7 +51,7 @@
         "material_id": "oak_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/ac/Oak_Slab_JE5_BE2.png",
         "name": "oak slab",
-        "url": "https://minecraft.fandom.com/wiki/Oak_Slab",
+        "url": "https://minecraft.wiki/w/Oak_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -59,7 +59,7 @@
         "material_id": "spruce_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/f1/Spruce_Log_%28UD%29_JE5_BE3.png",
         "name": "spruce log",
-        "url": "https://minecraft.fandom.com/wiki/Spruce_Log",
+        "url": "https://minecraft.wiki/w/Spruce_Log",
         "price": "8",
         "stack": "64"
     },
@@ -67,7 +67,7 @@
         "material_id": "stripped_spruce_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/09/Stripped_Spruce_Log_%28UD%29_JE2.png",
         "name": "stripped spruce log",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Spruce_Log",
+        "url": "https://minecraft.wiki/w/Stripped_Spruce_Log",
         "price": "8",
         "stack": "64"
     },
@@ -75,7 +75,7 @@
         "material_id": "spruce_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/25/Spruce_Wood_%28UD%29_JE5_BE2.png",
         "name": "spruce wood",
-        "url": "https://minecraft.fandom.com/wiki/Spruce_Wood",
+        "url": "https://minecraft.wiki/w/Spruce_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -83,7 +83,7 @@
         "material_id": "stripped_spruce_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/2b/Stripped_Spruce_Wood_%28UD%29_JE1_BE1.png",
         "name": "stripped spruce wood",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Spruce_Wood",
+        "url": "https://minecraft.wiki/w/Stripped_Spruce_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -91,7 +91,7 @@
         "material_id": "spruce_planks",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d4/Spruce_Planks_JE4_BE2.png",
         "name": "spruce planks",
-        "url": "https://minecraft.fandom.com/wiki/Spruce_Planks",
+        "url": "https://minecraft.wiki/w/Spruce_Planks",
         "price": "2",
         "stack": "64"
     },
@@ -99,7 +99,7 @@
         "material_id": "spruce_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/30/Spruce_Stairs_%28N%29_JE5_BE2.png",
         "name": "spruce stairs",
-        "url": "https://minecraft.fandom.com/wiki/Spruce_Stairs",
+        "url": "https://minecraft.wiki/w/Spruce_Stairs",
         "price": "3",
         "stack": "64"
     },
@@ -107,7 +107,7 @@
         "material_id": "spruce_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/a1/Spruce_Slab_JE4_BE2.png",
         "name": "spruce slab",
-        "url": "https://minecraft.fandom.com/wiki/Spruce_Slab",
+        "url": "https://minecraft.wiki/w/Spruce_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -115,7 +115,7 @@
         "material_id": "birch_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/db/Birch_Log_%28UD%29_JE5_BE3.png",
         "name": "birch log",
-        "url": "https://minecraft.fandom.com/wiki/Birch_Log",
+        "url": "https://minecraft.wiki/w/Birch_Log",
         "price": "8",
         "stack": "64"
     },
@@ -123,7 +123,7 @@
         "material_id": "stripped_birch_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7d/Stripped_Birch_Log_%28UD%29_JE2_BE2.png",
         "name": "stripped birch log",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Birch_Log",
+        "url": "https://minecraft.wiki/w/Stripped_Birch_Log",
         "price": "8",
         "stack": "64"
     },
@@ -131,7 +131,7 @@
         "material_id": "birch_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/3a/Birch_Wood_%28UD%29_JE5_BE2.png",
         "name": "birch wood",
-        "url": "https://minecraft.fandom.com/wiki/Birch_Wood",
+        "url": "https://minecraft.wiki/w/Birch_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -139,7 +139,7 @@
         "material_id": "stripped_birch_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/78/Stripped_Birch_Wood_%28UD%29_JE1_BE1.png",
         "name": "stripped birch wood",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Birch_Wood",
+        "url": "https://minecraft.wiki/w/Stripped_Birch_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -147,7 +147,7 @@
         "material_id": "birch_planks",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/cc/Birch_Planks_JE3_BE2.png",
         "name": "birch planks",
-        "url": "https://minecraft.fandom.com/wiki/Birch_Planks",
+        "url": "https://minecraft.wiki/w/Birch_Planks",
         "price": "2",
         "stack": "64"
     },
@@ -155,7 +155,7 @@
         "material_id": "birch_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1a/Birch_Stairs_%28N%29_JE4_BE2.png",
         "name": "birch stairs",
-        "url": "https://minecraft.fandom.com/wiki/Birch_Stairs",
+        "url": "https://minecraft.wiki/w/Birch_Stairs",
         "price": "3",
         "stack": "64"
     },
@@ -163,7 +163,7 @@
         "material_id": "birch_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/1b/Birch_Slab_JE3_BE2.png",
         "name": "birch slab",
-        "url": "https://minecraft.fandom.com/wiki/Birch_Slab",
+        "url": "https://minecraft.wiki/w/Birch_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -171,7 +171,7 @@
         "material_id": "jungle_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/2a/Jungle_Log_%28UD%29_JE6_BE3.png",
         "name": "jungle log",
-        "url": "https://minecraft.fandom.com/wiki/Jungle_Log",
+        "url": "https://minecraft.wiki/w/Jungle_Log",
         "price": "8",
         "stack": "64"
     },
@@ -179,7 +179,7 @@
         "material_id": "stripped_jungle_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/b4/Stripped_Jungle_Log_%28UD%29_JE4_BE3.png",
         "name": "stripped jungle log",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Jungle_Log",
+        "url": "https://minecraft.wiki/w/Stripped_Jungle_Log",
         "price": "8",
         "stack": "64"
     },
@@ -187,7 +187,7 @@
         "material_id": "jungle_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/cf/Jungle_Wood_%28UD%29_JE4_BE2.png",
         "name": "jungle wood",
-        "url": "https://minecraft.fandom.com/wiki/Jungle_Wood",
+        "url": "https://minecraft.wiki/w/Jungle_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -195,7 +195,7 @@
         "material_id": "stripped_jungle_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/20/Stripped_Jungle_Wood_%28UD%29_JE1_BE1.png",
         "name": "stripped jungle wood",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Jungle_Wood",
+        "url": "https://minecraft.wiki/w/Stripped_Jungle_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -203,7 +203,7 @@
         "material_id": "jungle_planks",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/06/Jungle_Planks_JE3_BE2.png",
         "name": "jungle planks",
-        "url": "https://minecraft.fandom.com/wiki/Jungle_Planks",
+        "url": "https://minecraft.wiki/w/Jungle_Planks",
         "price": "2",
         "stack": "64"
     },
@@ -211,7 +211,7 @@
         "material_id": "jungle_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/39/Jungle_Stairs_%28N%29_JE4_BE2.png",
         "name": "jungle stairs",
-        "url": "https://minecraft.fandom.com/wiki/Jungle_Stairs",
+        "url": "https://minecraft.wiki/w/Jungle_Stairs",
         "price": "3",
         "stack": "64"
     },
@@ -219,7 +219,7 @@
         "material_id": "jungle_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/37/Jungle_Slab_JE3_BE2.png",
         "name": "jungle slab",
-        "url": "https://minecraft.fandom.com/wiki/Jungle_Slab",
+        "url": "https://minecraft.wiki/w/Jungle_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -227,7 +227,7 @@
         "material_id": "acacia_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/fb/Acacia_Log_%28UD%29_JE5_BE3.png",
         "name": "acacia log",
-        "url": "https://minecraft.fandom.com/wiki/Acacia_Log",
+        "url": "https://minecraft.wiki/w/Acacia_Log",
         "price": "8",
         "stack": "64"
     },
@@ -235,7 +235,7 @@
         "material_id": "stripped_acacia_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/3b/Stripped_Acacia_Log_%28UD%29_JE2_BE2.png",
         "name": "stripped acacia log",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Acacia_Log",
+        "url": "https://minecraft.wiki/w/Stripped_Acacia_Log",
         "price": "8",
         "stack": "64"
     },
@@ -243,7 +243,7 @@
         "material_id": "acacia_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/8e/Acacia_Wood_%28UD%29_JE5_BE2.png",
         "name": "acacia wood",
-        "url": "https://minecraft.fandom.com/wiki/Acacia_Wood",
+        "url": "https://minecraft.wiki/w/Acacia_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -251,7 +251,7 @@
         "material_id": "stripped_acacia_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/24/Stripped_Acacia_Wood_%28UD%29_JE1_BE1.png",
         "name": "stripped acacia wood",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Acacia_Wood",
+        "url": "https://minecraft.wiki/w/Stripped_Acacia_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -259,7 +259,7 @@
         "material_id": "acacia_planks",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/56/Acacia_Planks_JE3_BE2.png",
         "name": "acacia planks",
-        "url": "https://minecraft.fandom.com/wiki/Acacia_Planks",
+        "url": "https://minecraft.wiki/w/Acacia_Planks",
         "price": "2",
         "stack": "64"
     },
@@ -267,7 +267,7 @@
         "material_id": "acacia_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/2/29/Acacia_Stairs_%28N%29_JE4_BE2.png",
         "name": "acacia stairs",
-        "url": "https://minecraft.fandom.com/wiki/Acacia_Stairs",
+        "url": "https://minecraft.wiki/w/Acacia_Stairs",
         "price": "3",
         "stack": "64"
     },
@@ -275,7 +275,7 @@
         "material_id": "acacia_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/8d/Acacia_Slab_JE3_BE2.png",
         "name": "acacia slab",
-        "url": "https://minecraft.fandom.com/wiki/Acacia_Slab",
+        "url": "https://minecraft.wiki/w/Acacia_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -283,7 +283,7 @@
         "material_id": "dark_oak_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c3/Dark_Oak_Log_%28UD%29_JE5_BE3.png",
         "name": "dark oak log",
-        "url": "https://minecraft.fandom.com/wiki/Dark_Oak_Log",
+        "url": "https://minecraft.wiki/w/Dark_Oak_Log",
         "price": "8",
         "stack": "64"
     },
@@ -291,7 +291,7 @@
         "material_id": "stripped_dark_oak_log",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/b0/Stripped_Dark_Oak_Log_%28UD%29_JE2.png",
         "name": "stripped dark oak log",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Dark_Oak_Log",
+        "url": "https://minecraft.wiki/w/Stripped_Dark_Oak_Log",
         "price": "8",
         "stack": "64"
     },
@@ -299,7 +299,7 @@
         "material_id": "dark_oak_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/5/5c/Dark_Oak_Wood_%28UD%29_JE5_BE2.png",
         "name": "dark oak wood",
-        "url": "https://minecraft.fandom.com/wiki/Dark_Oak_Wood",
+        "url": "https://minecraft.wiki/w/Dark_Oak_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -307,7 +307,7 @@
         "material_id": "stripped_dark_oak_wood",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/a3/Stripped_Dark_Oak_Wood_%28UD%29_JE1_BE1.png",
         "name": "stripped dark oak wood",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Dark_Oak_Wood",
+        "url": "https://minecraft.wiki/w/Stripped_Dark_Oak_Wood",
         "price": "11",
         "stack": "64"
     },
@@ -315,7 +315,7 @@
         "material_id": "dark_oak_planks",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/f/fe/Dark_Oak_Planks_JE3_BE2.png",
         "name": "dark oak planks",
-        "url": "https://minecraft.fandom.com/wiki/Dark_Oak_Planks",
+        "url": "https://minecraft.wiki/w/Dark_Oak_Planks",
         "price": "2",
         "stack": "64"
     },
@@ -323,7 +323,7 @@
         "material_id": "dark_oak_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/ec/Dark_Oak_Stairs_%28N%29_JE4_BE2.png",
         "name": "dark oak stairs",
-        "url": "https://minecraft.fandom.com/wiki/Dark_Oak_Stairs",
+        "url": "https://minecraft.wiki/w/Dark_Oak_Stairs",
         "price": "3",
         "stack": "64"
     },
@@ -331,7 +331,7 @@
         "material_id": "dark_oak_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/da/Dark_Oak_Slab_JE3_BE2.png",
         "name": "dark oak slab",
-        "url": "https://minecraft.fandom.com/wiki/Dark_Oak_Slab",
+        "url": "https://minecraft.wiki/w/Dark_Oak_Slab",
         "price": "1",
         "stack": "64"
     },
@@ -339,7 +339,7 @@
         "material_id": "crimson_stem",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/19/Crimson_Stem_%28UD%29_JE1.gif",
         "name": "crimson stem",
-        "url": "https://minecraft.fandom.com/wiki/Crimson_Stem",
+        "url": "https://minecraft.wiki/w/Crimson_Stem",
         "price": "10",
         "stack": "64"
     },
@@ -347,7 +347,7 @@
         "material_id": "stripped_crimson_stem",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/8/8c/Stripped_Crimson_Stem_%28UD%29_JE2_BE1.png",
         "name": "stripped crimson stem",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Crimson_Stem",
+        "url": "https://minecraft.wiki/w/Stripped_Crimson_Stem",
         "price": "10",
         "stack": "64"
     },
@@ -355,7 +355,7 @@
         "material_id": "crimson_hyphae",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/74/Crimson_Hyphae_%28UD%29_JE1.gif",
         "name": "crimson hyphae",
-        "url": "https://minecraft.fandom.com/wiki/Crimson_Hyphae",
+        "url": "https://minecraft.wiki/w/Crimson_Hyphae",
         "price": "13",
         "stack": "64"
     },
@@ -363,7 +363,7 @@
         "material_id": "stripped_crimson_hyphae",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/6/60/Stripped_Crimson_Hyphae_%28UD%29_JE1.png",
         "name": "stripped crimson hyphae",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Crimson_Hyphae",
+        "url": "https://minecraft.wiki/w/Stripped_Crimson_Hyphae",
         "price": "13",
         "stack": "64"
     },
@@ -371,7 +371,7 @@
         "material_id": "crimson_planks",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/d/d9/Crimson_Planks_JE1_BE1.png",
         "name": "crimson planks",
-        "url": "https://minecraft.fandom.com/wiki/Crimson_Planks",
+        "url": "https://minecraft.wiki/w/Crimson_Planks",
         "price": "3",
         "stack": "64"
     },
@@ -379,7 +379,7 @@
         "material_id": "crimson_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/71/Crimson_Stairs_%28N%29_JE1_BE1.png",
         "name": "crimson stairs",
-        "url": "https://minecraft.fandom.com/wiki/Crimson_Stairs",
+        "url": "https://minecraft.wiki/w/Crimson_Stairs",
         "price": "5",
         "stack": "64"
     },
@@ -387,7 +387,7 @@
         "material_id": "crimson_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/a7/Crimson_Slab_JE1_BE1.png",
         "name": "crimson slab",
-        "url": "https://minecraft.fandom.com/wiki/Crimson_Slab",
+        "url": "https://minecraft.wiki/w/Crimson_Slab",
         "price": "2",
         "stack": "64"
     },
@@ -395,7 +395,7 @@
         "material_id": "warped_stem",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/e/e2/Warped_Stem_%28UD%29_JE1.gif",
         "name": "warped stem",
-        "url": "https://minecraft.fandom.com/wiki/Warped_Stem",
+        "url": "https://minecraft.wiki/w/Warped_Stem",
         "price": "10",
         "stack": "64"
     },
@@ -403,7 +403,7 @@
         "material_id": "stripped_warped_stem",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/c8/Stripped_Warped_Stem_%28UD%29_JE2_BE1.png",
         "name": "stripped warped stem",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Warped_Stem",
+        "url": "https://minecraft.wiki/w/Stripped_Warped_Stem",
         "price": "10",
         "stack": "64"
     },
@@ -411,7 +411,7 @@
         "material_id": "warped_hyphae",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/b/ba/Warped_Hyphae_%28UD%29_JE1.gif",
         "name": "warped hyphae",
-        "url": "https://minecraft.fandom.com/wiki/Warped_Hyphae",
+        "url": "https://minecraft.wiki/w/Warped_Hyphae",
         "price": "13",
         "stack": "64"
     },
@@ -419,7 +419,7 @@
         "material_id": "stripped_warped_hyphae",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/1/12/Stripped_Warped_Hyphae_%28UD%29_JE1.png",
         "name": "stripped warped hyphae",
-        "url": "https://minecraft.fandom.com/wiki/Stripped_Warped_Hyphae",
+        "url": "https://minecraft.wiki/w/Stripped_Warped_Hyphae",
         "price": "13",
         "stack": "64"
     },
@@ -427,7 +427,7 @@
         "material_id": "warped_planks",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/a/a5/Warped_Planks_JE1_BE1.png",
         "name": "warped planks",
-        "url": "https://minecraft.fandom.com/wiki/Warped_Planks",
+        "url": "https://minecraft.wiki/w/Warped_Planks",
         "price": "3",
         "stack": "64"
     },
@@ -435,7 +435,7 @@
         "material_id": "warped_stairs",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/c/cc/Warped_Stairs_%28N%29_JE1_BE1.png",
         "name": "warped stairs",
-        "url": "https://minecraft.fandom.com/wiki/Warped_Stairs",
+        "url": "https://minecraft.wiki/w/Warped_Stairs",
         "price": "5",
         "stack": "64"
     },
@@ -443,7 +443,7 @@
         "material_id": "warped_slab",
         "image": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/7/7b/Warped_Slab_JE1_BE1.png",
         "name": "warped slab",
-        "url": "https://minecraft.fandom.com/wiki/Warped_Slab",
+        "url": "https://minecraft.wiki/w/Warped_Slab",
         "price": "2",
         "stack": "64"
     }


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.